### PR TITLE
Copy over the govuk-aws script from govuk-guix

### DIFF
--- a/bin/govuk-aws
+++ b/bin/govuk-aws
@@ -1,0 +1,178 @@
+#!/bin/sh
+
+if [ ! -n "$BASH" ] ; then
+    exec bash "$0" $@
+fi
+
+set -e
+set -o pipefail
+
+profile="${PROFILE:-govuk-integration}"
+
+cache_directory="${XDG_CACHE_HOME-$HOME/.cache}/govuk/aws-credentials"
+cached_aws_credentials="$cache_directory/${profile}"
+
+prompt_for_mfa_token() {
+    prompt=$'\ngovuk-aws: Enter AWS MFA token: '
+    if [ ! -z "${AWS_EXPIRATION-}" ]; then
+        prompt=$'\ngovuk-aws: Your AWS session has expired. Enter AWS MFA token: '
+    fi
+    read -p "${prompt}" MFA_TOKEN
+}
+
+read_aws_config_file() {
+    if [ ! -f ~/.aws/config ]; then
+        echo "govuk: aws: ~/.aws/config doesn't exist" >&2
+        echo "govuk: aws: please setup the relevant GOV.UK AWS configuration" >&2
+        exit 1
+    fi
+
+    if ! grep --quiet --fixed-strings "[profile $profile]" ~/.aws/config; then
+        echo "govuk: aws: couldn't find the '$profile' profile in ~/.aws/config"
+        if grep --quiet "^\[profile " ~/.aws/config; then
+            echo "govuk: aws: the following profiles are available in ~/.aws/config"
+            sed -n -e 's/\[profile \(.*\)\]/  \1/p' ~/.aws/config
+        else
+            echo "govuk: aws: it doesn't look like ~/.aws/config contains any profiles"
+        fi
+        exit 1
+    fi
+
+    ROLE_ARN=$(awk '/profile '"$profile"'/ {profile=1} /role_arn/ && profile==1 {print $3; exit}' ~/.aws/config)
+    MFA_SERIAL=$(awk '/profile '"$profile"'/ {profile=1} /mfa_serial/ && profile==1 {print $3; exit}' ~/.aws/config)
+    SOURCE_PROFILE=$(awk '/profile '"$profile"'/ {profile=1} /source_profile/ && profile==1 {print $3; exit}' ~/.aws/config)
+}
+
+parse_aws_assume_role_output() {
+    ACCESS_KEY_ID=$(echo ${AWS_ASSUME_ROLE_OUTPUT} | ruby -e 'require "json"; c = JSON.parse(STDIN.read)["Credentials"]; STDOUT << c["AccessKeyId"]')
+    SECRET_ACCESS_KEY=$(echo ${AWS_ASSUME_ROLE_OUTPUT} | ruby -e 'require "json"; c = JSON.parse(STDIN.read)["Credentials"]; STDOUT << c["SecretAccessKey"]')
+    SESSION_TOKEN=$(echo ${AWS_ASSUME_ROLE_OUTPUT} | ruby -e 'require "json"; c = JSON.parse(STDIN.read)["Credentials"]; STDOUT << c["SessionToken"]')
+    EXPIRATION=$(echo ${AWS_ASSUME_ROLE_OUTPUT} | ruby -e 'require "json"; c = JSON.parse(STDIN.read)["Credentials"]; STDOUT << c["Expiration"]')
+}
+
+session_has_expired() {
+    export EXPIRATION
+    if [ $(ruby -r time -e 'puts (Time.parse(ENV["EXPIRATION"]) - Time.now).floor') -lt 300 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+run_aws_assume_role() {
+    SESSION_NAME=$(whoami)-$(date +%d-%m-%y_%H-%M)
+    read_aws_config_file
+
+    if [ -z "$MFA_TOKEN" ]; then
+        prompt_for_mfa_token
+    fi
+
+    aws_assume_role="aws sts assume-role \
+                    --profile gds \
+                    --role-arn $ROLE_ARN \
+                    --role-session-name $SESSION_NAME \
+                    --serial-number $MFA_SERIAL \
+                    --duration-seconds 28800 \
+                    --token-code $MFA_TOKEN"
+
+    AWS_ASSUME_ROLE_OUTPUT=$(${aws_assume_role})
+
+    if [[ $? != 0 ]]; then
+        exit "govuk-aws: aws sts assume-role: failed"
+    fi
+
+    mkdir -p "$(dirname $cached_aws_credentials)"
+    echo $AWS_ASSUME_ROLE_OUTPUT > $cached_aws_credentials
+
+    parse_aws_assume_role_output
+}
+
+get_aws_credentials() {
+    if [ -f "$cached_aws_credentials" ]; then
+        AWS_ASSUME_ROLE_OUTPUT=$(<$cached_aws_credentials)
+        parse_aws_assume_role_output
+
+        if session_has_expired; then
+            run_aws_assume_role
+        fi
+    else
+        run_aws_assume_role
+    fi
+}
+
+test_aws_cli_installed() {
+  if ! command -v aws 2>/dev/null; then
+    echo "You need to have the aws cli tool installed to run govuk aws.\r\nIt looks like you don't.\r\nPlease visit https://aws.amazon.com/cli/ for installation instructions."
+    exit 1
+  fi
+}
+
+if [ "$1" == "--profile" ]; then
+    profile="$2"
+    cache_directory="${XDG_CACHE_HOME-$HOME/.cache}/govuk-guix"
+    cached_aws_credentials="$cache_directory/${profile}-aws-credentials"
+
+    test_aws_cli_installed
+    get_aws_credentials
+
+    if [ "$3" == "--export" ]; then
+        echo "export AWS_ACCESS_KEY_ID=\"$ACCESS_KEY_ID\""
+        echo "export AWS_SECRET_ACCESS_KEY=\"$SECRET_ACCESS_KEY\""
+        echo "export AWS_SESSION_TOKEN=\"$SESSION_TOKEN\""
+    elif [ "$3" == "--export-json" ]; then
+        echo "{ \"access_key_id\": \"$ACCESS_KEY_ID\", \"secret_access_key\": \"$SECRET_ACCESS_KEY\", \"session_token\": \"$SESSION_TOKEN\" }"
+    elif [ "$3" == "--export-plain" ]; then
+        echo
+        echo -e "  Profile\t\t $profile"
+        echo
+        echo -e "  Session expires\t $EXPIRATION"
+        echo
+        echo -e "  Access key id\t\t $ACCESS_KEY_ID"
+        echo
+        echo -e "  Secret access key\t $SECRET_ACCESS_KEY"
+        echo
+        echo -e "  Session token\t\t $SESSION_TOKEN"
+        echo
+    elif [ "$3" == "--export-pretty" ] || [ "$3" == "" ]; then
+        bold="$(tput bold)"
+        reset="$(tput sgr0)"
+
+        echo
+        echo -e "  Profile\t\t $profile"
+        echo
+        echo -e "  Session expires\t $EXPIRATION"
+        echo
+        echo -e "  Access key id\t\t $bold$ACCESS_KEY_ID$reset"
+        echo
+        echo -e "  Secret access key\t $bold$SECRET_ACCESS_KEY$reset"
+        echo
+        echo -e "  Session token\t\t $bold$SESSION_TOKEN$reset"
+        echo
+    elif [ "$3" == "--" ]; then
+        export AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY"
+        export AWS_SESSION_TOKEN="$SESSION_TOKEN"
+
+        exec "${@:3}"
+    else
+        echo "govuk: aws: unknown argument '$3'"
+        echo "govuk: aws: valid arguments are:"
+        echo
+        echo "  --export         to output the shell commands for the AWS credentials"
+        echo "  --export-plain   to output the values for the AWS credentials without bold styling"
+        echo "  --export-pretty  to output the values for the AWS credentials"
+        echo "  --export-json    to output JSON describing the AWS credentials"
+        echo "  --               to run a command with the AWS credentials set in the environment,"
+        echo "                   e.g. 'govuk aws --profile=govuk-integration -- aws s3 ls'"
+        exit 1
+    fi
+elif [ "$1" == "--" ]; then
+    exec "${@:2}"
+else
+    echo "govuk: aws: unknown argument '$1'"
+    echo "govuk: aws: valid arguments are:"
+    echo
+    echo "  --profile    followed by a profile, e.g. 'govuk aws --profile govuk-integration -- aws s3 ls'"
+    echo "  --           on it's own to not assume a role, e.g. 'govuk aws -- aws s3 ls'"
+    exit 1
+fi


### PR DESCRIPTION
Like govuk-connect, this isn't connected to Guix, but that was just a
convinient place to store the script prior to the creation of the
govuk-cli repository.

This was originally written to provide a stateless alternative to
govukcli, as well as making it easier to integrate in to scripts like
`govuk data`. Additionally, I still think it's useful to keep aroun
given it's a lot simpler compared to the similar functionality in the
govukcli or gds-cli scripts, the latter which requires installing
aws-vault as I understand it.