### PR TITLE
Stop output of aws binary location when running

### DIFF
--- a/bin/govuk-aws
+++ b/bin/govuk-aws
@@ -101,7 +101,7 @@ get_aws_credentials() {
 }
 
 test_aws_cli_installed() {
-  if ! command -v aws 2>/dev/null; then
+  if ! command -v aws > /dev/null; then
     echo "You need to have the aws cli tool installed to run govuk aws.\r\nIt looks like you don't.\r\nPlease visit https://aws.amazon.com/cli/ for installation instructions."
     exit 1
   fi


### PR DESCRIPTION
`2>` redirects stderr and was causing the location of the binary to be
printed when testing for the existence of the aws binary. This can cause
issues in that the output is no longer interpreted as valid json (for
example). Instead we want to suppress the output of the location of the
binary.