### PR TITLE
Handle different formattings for aws config

### DIFF
--- a/bin/govuk-aws
+++ b/bin/govuk-aws
@@ -38,9 +38,9 @@ read_aws_config_file() {
         exit 1
     fi
 
-    ROLE_ARN=$(awk '/profile '"$profile"'/ {profile=1} /role_arn/ && profile==1 {print $3; exit}' ~/.aws/config)
-    MFA_SERIAL=$(awk '/profile '"$profile"'/ {profile=1} /mfa_serial/ && profile==1 {print $3; exit}' ~/.aws/config)
-    SOURCE_PROFILE=$(awk '/profile '"$profile"'/ {profile=1} /source_profile/ && profile==1 {print $3; exit}' ~/.aws/config)
+    ROLE_ARN=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /role_arn/ && profile==1 {print $2; exit}' ~/.aws/config)
+    MFA_SERIAL=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /mfa_serial/ && profile==1 {print $2; exit}' ~/.aws/config)
+    SOURCE_PROFILE=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /source_profile/ && profile==1 {print $2; exit}' ~/.aws/config)
 }
 
 parse_aws_assume_role_output() {

--- a/bin/govuk-aws
+++ b/bin/govuk-aws
@@ -41,6 +41,10 @@ read_aws_config_file() {
     ROLE_ARN=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /role_arn/ && profile==1 {print $2; exit}' ~/.aws/config)
     MFA_SERIAL=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /mfa_serial/ && profile==1 {print $2; exit}' ~/.aws/config)
     SOURCE_PROFILE=$(awk -F "=" '/profile '"$profile"'/ {profile=1} /source_profile/ && profile==1 {print $2; exit}' ~/.aws/config)
+
+    if [ -z "$ROLE_ARN" ]; then
+        echo "govuk: aws: error extracting the role_arn from ~/.aws/config"
+    fi
 }
 
 parse_aws_assume_role_output() {


### PR DESCRIPTION
To cope with both `role_arn=...` and `role_arn = ...` in ~/.aws/config.