### PR TITLE
Fix Makefile `install` syntax for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ BIN=$(DESTDIR)/bin
 
 install:
 	mkdir -p $(BIN)
-	install -t $(BIN) bin/govuk
-	install -t $(BIN) bin/govuk-connect
-	install -t $(BIN) bin/govuk-aws
+	cp bin/govuk $(BIN)
+	cp bin/govuk-connect $(BIN)
+	cp bin/govuk-aws $(BIN)


### PR DESCRIPTION
- The previous `install -t` worked fine on Linux, where @cbaines and
  I tested, but the macOS non-GNU implementation of `install` doesn't have
  `-t`.
- Use `cp` as that's definitely cross-platform.

Thanks to @camdesgov who discovered this problem!