### PR TITLE
Require at least Ruby 2 in govuk-connect

### DIFF
--- a/bin/govuk-connect
+++ b/bin/govuk-connect
@@ -211,6 +211,24 @@ def strings_similar_to(target, strings)
   end
 end
 
+def check_ruby_version_greater_than(required_major:, required_minor:)
+  major, minor = RUBY_VERSION.split '.'
+
+  insufficient_version = (
+    major.to_i < required_major || (
+      major.to_i == required_major &&
+      minor.to_i < required_minor
+    )
+  )
+
+  if insufficient_version
+    error "insufficient Ruby version: #{RUBY_VERSION}"
+    error "must be at least #{required_major}.#{required_minor}"
+
+    exit 1
+  end
+end
+
 def port_free?(port)
   # No idea how well this works, but it's hopefully better than nothing
 
@@ -973,6 +991,8 @@ TYPES = {
 }
 
 def main
+  check_ruby_version_greater_than(required_major: 2, required_minor: 0)
+
   double_dash_index = ARGV.index '--'
   if double_dash_index
     rest = ARGV[double_dash_index + 1, ARGV.length]


### PR DESCRIPTION
As I think I've seen issues with using older Ruby versions.