### PR TITLE
Add workflow for creating a new versioned release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Create Versioned Release
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: 'The semver level of the release'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+      - run: |
+          NEW_VERSION=$(scripts/calculate-semver.sh "${{ github.event.inputs.level }}")
+          echo "Calculated new version: $NEW_VERSION"
+          git tag "$NEW_VERSION"
+          echo "Pushing new tag: $NEW_VERSION"
+          git push origin "$NEW_VERSION"

--- a/scripts/calculate-semver.sh
+++ b/scripts/calculate-semver.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $(basename "$0") <major|minor|patch>" >&2
+    exit 1
+fi
+
+level=$1
+
+current=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n1)
+current=${current:-v0.0.0}
+
+IFS=. read -r major minor patch <<<"${current#v}"
+
+case $level in
+    major) next="$((major + 1)).0.0" ;;
+    minor) next="${major}.$((minor + 1)).0" ;;
+    patch) next="${major}.${minor}.$((patch + 1))" ;;
+    *)
+        echo "error: unknown level '$level' (expected major, minor, or patch)" >&2
+        exit 1
+        ;;
+esac
+
+echo "v${next}"


### PR DESCRIPTION
This adds a new GHA workflow which can be triggered manually to create a new versioned release. It takes a single parameter, the bump level for the release (either major, minor or patch). It also includes a script which calculates the new version number based on the last version tag.

There are a couple of popular GHA actions to calculate semver version bumps, but I decided against using them since the logic is very simple and I don't think the supply chain risk would be worth the convenience.

Another GHA workflow for actually performing the release will be added in the future.

https://github.com/alphagov/govuk-infrastructure/issues/4169