### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: Publish Versioned Release
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: "2.15.4"
+          args: release --clean
+        env:
+          GITHUB_PAT_HOMEBREW: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,3 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
-
-# The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
@@ -10,7 +5,6 @@ version: 2
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
     - scripts/completions.sh
 
@@ -65,6 +59,7 @@ homebrew_casks:
     repository:
       owner: alphagov
       name: homebrew-gds
+      token: "{{ .Env.GITHUB_PAT_HOMEBREW }}"
     hooks:
       post:
         install: |


### PR DESCRIPTION
Add a workflow that runs when new tags are created.
This workflow runs `goreleaser release --clean`, which:
1. Builds the Go binary
2. Creates a macOS universal binary for use on x86 and arm
3. Creates a GitHub release for the new version (changelog is worked out from commit messages)
4. Update the homebrew tap

Also clean up the .goreleaser.yaml file, getting rid of some comments that aren't helpful

https://github.com/alphagov/govuk-infrastructure/issues/4169