### PR TITLE
Explicitly call the publish workflow from the release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,17 +1,20 @@
 name: Publish Versioned Release
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    secrets:
+      GOVUK_CI_GITHUB_API_TOKEN:
+        required: true
+        description: "GitHub token with permissions to publish to the Homebrew tap"
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,4 +26,11 @@ jobs:
           echo "Calculated new version: $NEW_VERSION"
           git tag "$NEW_VERSION"
           echo "Pushing new tag: $NEW_VERSION"
-          git push origin "$NEW_VERSION"
+          git push --tags
+  publish:
+    uses: ./.github/workflows/publish.yaml
+    needs: release
+    permissions:
+      contents: write
+    secrets:
+      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
The on tag push workflow trigger doesn't seem to do anything if the tag was pushed by GHA. Calling it explicitly solves this issue, while still making the publish workflow runnable manually for debugging.

https://github.com/alphagov/govuk-infrastructure/issues/4169