### PR TITLE
Provide version to cobra root command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ before:
 
 builds:
   - main: main.go
+    ldflags:
+      - -s -w -X github.com/alphagov/govuk-cli/cmd.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version string = "dev"
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "govuk",
-	Short: "GOV.UK Platform CLI",
-	Long:  `A CLI for interacting with the GOV.UK Platform.`,
+	Use:     "govuk",
+	Short:   "GOV.UK Platform CLI",
+	Long:    `A CLI for interacting with the GOV.UK Platform.`,
+	Version: version,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
This allows the user to run govuk-cli --version and have it report the correct version number

https://github.com/alphagov/govuk-infrastructure/issues/4169