### PR TITLE
Fetch Go dependencies during Make build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 dist/
 completions/
+vendor/
 govuk-cli
 govuk
 govuk-debug

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,32 @@
-go_files := $(shell find . -type f -name '*.go') go.mod go.sum
+.DEFAULT: govuk
 
-govuk: ${go_files}
+go_files := $(shell find . -type f -name '*.go') go.mod go.sum
+go_vendor_files := $(shell find . -type f -name "*.go" -path "./vendor/*")
+
+##
+# Building
+# Targets for building the project
+##
+
+govuk: ${go_files} vendor
 	go build -o govuk main.go
 
 govuk-debug: ${go_files}
 	env $(GO_BUILD_ENV) go build -o govuk-debug -cover -covermode atomic main.go
 	GOCOVERDIR=coverage/version ./govuk-debug --version
- 
+
 .PHONY: clean
 clean:
 	rm -f govuk govuk-debug
 	rm -f coverage/*/covmeta.* coverage/*/covcounters.* coverage/report/*.* coverage/report-main/*.*
+
+vendor: ${go_vendor_files}
+	go mod vendor
+
+##
+# Testing
+# Targets for different types of test for the project
+##
 
 .PHONY: unit_tests
 unit_tests:
@@ -20,7 +36,7 @@ unit_tests:
 .PHONY: integration_tests
 integration_tests: govuk-debug
 	go test -race -v ./integration_tests
-		
+
 .PHONY: coverage_report
 coverage_report:
 	go tool covdata merge -i coverage/unit,coverage/integration/,coverage/version -o coverage/merged/


### PR DESCRIPTION
## What

The existing target assumed the presence of the vendor directory, which made the build target fail on a fresh checkout. The target now depends on both the vendor directory, and the files within it.

Also ignores the `vendor/` directory in Git.

## How to review

1. Do a clean checkout (or delete `vendor/`)
2. `make govuk`
3. Repeat 1
4. `make` (to test the default target setting)
