### PR TITLE
Configure dependabot for Go dependencies and Renovate for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+      "config:recommended",
+      "helpers:pinGitHubActionDigests"
+  ],
+  "enabledManagers": ["github-actions"],
+  "minimumReleaseAge": "10 days"
+}


### PR DESCRIPTION
Dependabot is standard for GOV.UK, but Renovate handles GHA updates better (it can update version numbers provided to actions, such as golangci-lint)

See https://github.com/alphagov/router/pull/688 for an explanation of why we should use both

https://github.com/alphagov/govuk-infrastructure/issues/4204