### PR TITLE
renovate: Don't manage GHA workflows from govuk-infrastructure

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
       "helpers:pinGitHubActionDigests"
   ],
   "enabledManagers": ["github-actions"],
-  "minimumReleaseAge": "10 days"
+  "minimumReleaseAge": "10 days",
+  "packageRules": [
+    {
+      "matchPackageNames": ["alphagov/govuk-infrastructure"],
+      "matchDepTypes": ["action"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
We don't want these pinning to a commit, so get Renovate to ignore them completely

https://github.com/alphagov/govuk-infrastructure/issues/4204